### PR TITLE
Allow plugin users to specify custom dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,15 +133,18 @@ Where the `env.URL` is provided by Netlify at build time. Your host may offer a 
 
 ## CLI Config Options
 
-| Option       | Type                                                      | Default     |
-| ------------ | --------------------------------------------------------- | ----------- |
-| siteName     | string                                                    | 11ty Rocks! |
-| outputDir    | string                                                    | \_site      |
-| imageDir     | string                                                    | previews    |
-| dataFile     | string                                                    | pages.json  |
-| templatePath | string                                                    |             |
-| stylesPath   | string                                                    |             |
-| theme        | enum: 'blue' \| 'green' \| 'minimal' \| 'sunset' \| 'pop' | blue        |
+| Option            | Type                                                      | Default     |
+|-------------------|-----------------------------------------------------------|-------------|
+| siteName          | string                                                    | 11ty Rocks! |
+| outputDir         | string                                                    | \_site      |
+| imageDir          | string                                                    | previews    |
+| dataFile          | string                                                    | pages.json  |
+| templatePath      | string                                                    |             |
+| stylesPath        | string                                                    |             |
+| theme             | enum: 'blue' \| 'green' \| 'minimal' \| 'sunset' \| 'pop' | blue        |
+| width             | number                                                    | 600         |
+| height            | number                                                    | 315         |
+| deviceScaleFactor | number                                                    | 2           |
 
 ## Config Examples
 
@@ -162,6 +165,12 @@ To select, from one of the predefined themes, pass `--theme [themename]` where `
 - minimal
 - sunset
 - pop
+
+### Custom image dimensions
+
+By default, this plugin will create social images that are 600px wide and 315px tall. To choose different dimensions, pass `--width` and `--height` arguments, as in `--width 1280 --height 720`.
+
+The default device scale factor (or [device pixel ratio](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio)) is 2, emulating high-dots-per-inch/Retina displays. To change the device scale factor, you can pass `---deviceScaleFactor`, as in `--deviceScaleFactor 1`.
 
 ### Custom preview directory to output images
 
@@ -210,7 +219,7 @@ You can pass both a custom template and stylesheet by defining both CLI options,
 Since this full example includes style, the only option missing is `theme` since it would have no additional effect.
 
 ```bash
-eleventy-social-images --siteName 'My Cool Site' --outputDir public --dataFile src/_generate/pages.json --previewDir imgs --templatePath social/template.html --stylesPath social/style.css"
+eleventy-social-images --siteName 'My Cool Site' --outputDir public --dataFile src/_generate/pages.json --previewDir imgs --templatePath social/template.html --stylesPath social/style.css --width 1280 --height 720 --deviceScaleFactor 1"
 ```
 
 ## Colophon

--- a/bin/social-images.js
+++ b/bin/social-images.js
@@ -13,6 +13,9 @@ const defaults = {
   templatePath: "", // ex. social/template.html
   stylesPath: "", // ex. social/style.css,
   theme: "blue", // enum: 'blue' | 'green' | 'minimal' | 'sunset' | 'pop'
+  width: 600,
+  height: 315,
+  deviceScaleFactor: 2
 };
 
 const {
@@ -23,6 +26,9 @@ const {
   templatePath,
   stylesPath,
   theme,
+  width,
+  height,
+  deviceScaleFactor
 } = {
   ...defaults,
   ...argv,
@@ -91,9 +97,9 @@ const dataPath = fs.realpathSync(dataFile);
 
   // Set the viewport to your preferred image size
   await page.setViewport({
-    width: 600,
-    height: 315,
-    deviceScaleFactor: 2,
+    width,
+    height,
+    deviceScaleFactor,
   });
 
   // Create a `previews` directory in the public folder
@@ -114,7 +120,7 @@ const dataPath = fs.realpathSync(dataFile);
     await page.screenshot({
       path: `${dir}/${post.imgName}.png`,
       type: "png",
-      clip: { x: 0, y: 0, width: 600, height: 315 },
+      clip: { x: 0, y: 0, width, height },
     });
   }
 


### PR DESCRIPTION
Howdy, Stephanie! This is a fantastic plugin, and I'm super appreciative that you've put this together!

I decided to try to use this to generate YouTube thumbnails, and ran into a snag, since optimal thumbnails are 1280px wide and 720px tall.

This pull request should allow plugin users to provide custom `width`, `height`, and `deviceScaleFactor` arguments. The defaults remain `600`, `315`, and `2`. Please let me know if you have any questions, concerns, or feedback!